### PR TITLE
Changing Rubocop's forced style on hash indentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,6 @@ DotPosition:
 
 AlignParameters:
   EnforcedStyle: with_fixed_indentation
+
+IndentHash:
+  EnforcedStyle: consistent


### PR DESCRIPTION
Hound says:

"Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis."

I think we should indent as per normal indentation, to match method params & also the existing style in Laserwolf. 

Thoughts? 
