### PR TITLE
Cdsearch 643 - Add user.uuid_is_new boolean to rack env

### DIFF
--- a/lib/macmillan/utils/middleware/uuid.rb
+++ b/lib/macmillan/utils/middleware/uuid.rb
@@ -22,7 +22,7 @@ module Macmillan
         end
 
         class CallHandler
-          attr_reader :app, :request, :user_env_key, :user_id_method, :cookie_key
+          attr_reader :app, :request, :user_env_key, :user_id_method, :cookie_key, :rack_errors
 
           def initialize(env, app, user_env_key, user_id_method, cookie_key)
             @app            = app
@@ -30,6 +30,7 @@ module Macmillan
             @user_env_key   = user_env_key
             @user_id_method = user_id_method
             @cookie_key     = cookie_key
+            @rack_errors    = env['rack.errors']
 
             env[cookie_key] = final_user_uuid
           end

--- a/lib/macmillan/utils/middleware/uuid.rb
+++ b/lib/macmillan/utils/middleware/uuid.rb
@@ -22,7 +22,7 @@ module Macmillan
         end
 
         class CallHandler
-          attr_reader :app, :request, :user_env_key, :user_id_method, :cookie_key, :rack_errors
+          attr_reader :app, :request, :user_env_key, :user_id_method, :cookie_key, :rack_errors, :uuid_is_new_key
 
           def initialize(env, app, user_env_key, user_id_method, cookie_key)
             @app            = app
@@ -31,8 +31,10 @@ module Macmillan
             @user_id_method = user_id_method
             @cookie_key     = cookie_key
             @rack_errors    = env['rack.errors']
+            @uuid_is_new_key = "#{cookie_key}_is_new"
 
-            env[cookie_key] = final_user_uuid
+            env[cookie_key]      = final_user_uuid
+            env[uuid_is_new_key] = true if uuid_is_new?
           end
 
           def finish
@@ -69,6 +71,7 @@ module Macmillan
           def store_cookie?
             final_user_uuid != uuid_from_cookies
           end
+          alias_method :uuid_is_new?, :store_cookie?
 
           def save_cookie
             cookie_value = { value: final_user_uuid, path: '/', expires: DateTime.now.next_year.to_time }

--- a/spec/lib/macmillan/utils/middleware/uuid_spec.rb
+++ b/spec/lib/macmillan/utils/middleware/uuid_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Macmillan::Utils::Middleware::Uuid do
         expect(app).to receive(:call).with(hash_including('user.uuid' => user_uuid)).and_return(app_return)
         _status, _headers, _body = subject.call(request.env)
       end
+
+      it 'tells following rack app the user_uuid is new' do
+        expect(app).to receive(:call).with(hash_including('user.uuid_is_new' => true)).and_return(app_return)
+        _status, _headers, _body = subject.call(request.env)
+      end
     end
 
     context 'who also has a randomly assigned user_uuid cookie (from a previous non-authenticated session)' do
@@ -34,6 +39,11 @@ RSpec.describe Macmillan::Utils::Middleware::Uuid do
       it 'replaces this cookie with one based on the users user_id' do
         _status, headers, _body = subject.call(request.env)
         expect(headers['Set-Cookie']).to include("user.uuid=#{user_uuid}")
+      end
+
+      it 'tells following rack app the user_uuid is new' do
+        expect(app).to receive(:call).with(hash_including('user.uuid_is_new' => true)).and_return(app_return)
+        _status, _headers, _body = subject.call(request.env)
       end
     end
   end
@@ -54,6 +64,11 @@ RSpec.describe Macmillan::Utils::Middleware::Uuid do
         _status, headers, _body = subject.call(request.env)
         expect(headers['Set-Cookie']).to include('user.uuid=wibble')
       end
+
+      it 'tells following rack app the user_uuid is new' do
+        expect(app).to receive(:call).with(hash_including('user.uuid_is_new' => true)).and_return(app_return)
+        _status, _headers, _body = subject.call(request.env)
+      end
     end
 
     context 'who has visited before and has a user_uuid cookie' do
@@ -69,6 +84,13 @@ RSpec.describe Macmillan::Utils::Middleware::Uuid do
       it 'does not try to replace the cookie' do
         _status, headers, _body = subject.call(request.env)
         expect(headers['Set-Cookie']).to be_nil
+      end
+
+      it 'does not tell following rack app the user_uuid is new' do
+        expect(app).to receive(:call) do |args|
+          expect(args).not_to have_key('user.uuid_is_new')
+        end.and_return(app_return)
+        _status, _headers, _body = subject.call(request.env)
       end
     end
   end


### PR DESCRIPTION
Allows later middleware to make decisions about storing the uuid value, particularly useful in environments using https://github.com/springernature/thundermole .