### PR TITLE
Add middleware for setting cookie message cookie

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,11 @@ Metrics/LineLength:
   Description: 'Limit lines to 120 characters.'
   Max: 120
 
+Metrics/BlockLength:
+  ExcludedMethods:
+    - describe
+    - context
+
 Style/Documentation:
   Enabled: false
 
@@ -25,6 +30,25 @@ Style/AlignParameters:
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%':  ()
+    '%i': ()
+    '%I': ()
+    '%q': ()
+    '%Q': ()
+    '%r': '{}'
+    '%s': ()
+    '%w': '[]'
+    '%W': '[]'
+    '%x': ()
+
+Style/RegexpLiteral:
+  AllowInnerSlashes: true
 
 Style/CollectionMethods:
   PreferredMethods:

--- a/lib/macmillan/utils/middleware.rb
+++ b/lib/macmillan/utils/middleware.rb
@@ -1,8 +1,9 @@
 module Macmillan
   module Utils
     module Middleware
-      autoload :WeakEtags, 'macmillan/utils/middleware/weak_etags'
-      autoload :Uuid,      'macmillan/utils/middleware/uuid'
+      autoload :CookieMessage, 'macmillan/utils/middleware/cookie_message'
+      autoload :WeakEtags,     'macmillan/utils/middleware/weak_etags'
+      autoload :Uuid,          'macmillan/utils/middleware/uuid'
     end
   end
 end

--- a/lib/macmillan/utils/middleware/cookie_message.rb
+++ b/lib/macmillan/utils/middleware/cookie_message.rb
@@ -1,0 +1,71 @@
+require 'rack/request'
+require 'rack/response'
+require 'uri'
+
+module Macmillan
+  module Utils
+    module Middleware
+      class CookieMessage
+        YEAR = 31_536_000
+        COOKIE = 'euCookieNotice'.freeze
+
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          request = Rack::Request.new(env)
+
+          if cookies_accepted?(request)
+            redirect_back(request)
+          else
+            @app.call(env)
+          end
+        end
+
+        private
+
+        def cookies_accepted?(request)
+          request.post? &&
+            request.cookies[COOKIE] != 'accepted' &&
+            request.params['cookies'] == 'accepted'
+        end
+
+        def redirect_back(request)
+          response = Rack::Response.new
+          location = build_location(request)
+
+          response.redirect(location)
+          response.set_cookie(COOKIE, cookie_options(request))
+
+          response.to_a
+        end
+
+        def cookie_options(request)
+          {
+            value:   'accepted',
+            domain:  request.host_with_port,
+            path:    '/',
+            expires: Time.now.getutc + YEAR
+          }
+        end
+
+        def build_location(request)
+          begin
+            uri = URI.parse(request.referrer.to_s)
+          rescue URI::InvalidURIError
+            uri = URI.parse(request.url)
+          end
+
+          # Check that the redirect is an internal one for security reasons:
+          # https://webmasters.googleblog.com/2009/01/open-redirect-urls-is-your-site-being.html
+          internal_redirect?(request, uri) ? uri.to_s : request.url
+        end
+
+        def internal_redirect?(request, uri)
+          request.host == uri.host && request.port == uri.port
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/macmillan/utils/middleware/cookie_message_spec.rb
+++ b/spec/lib/macmillan/utils/middleware/cookie_message_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+RSpec.describe Macmillan::Utils::Middleware::CookieMessage do
+  let(:app) { ->(_) { [200, {}, %w[body]] } }
+  let(:env) { env_for(url, request_headers) }
+  let(:request_headers) { default_headers.merge(extra_headers) }
+  let(:default_headers) { { 'REQUEST_METHOD' => request_method } }
+  let(:extra_headers) { {} }
+
+  subject { described_class.new(app) }
+
+  let(:response) { subject.call(env) }
+  let(:status) { response[0] }
+  let(:headers) { response[1] }
+  let(:body) { response[2] }
+  let(:cookie) { headers['Set-Cookie'] }
+  let(:location) { headers['Location'] }
+
+  context 'when request params contains cookies=accepted' do
+    let(:url) { 'http://www.nature.com/?cookies=accepted' }
+
+    context 'and the request method is GET' do
+      let(:request_method) { 'GET' }
+
+      it 'calls the app' do
+        expect(app).to receive(:call).with(env).and_call_original
+        expect(response).to eq([200, {}, %w[body]])
+      end
+    end
+
+    context 'and the request method is POST' do
+      let(:request_method) { 'POST' }
+
+      context 'and the euNoticeCookie is not set' do
+        before do
+          allow(Time).to receive(:now).and_return(Time.utc(2017, 1, 31))
+          expect(app).not_to receive(:call)
+        end
+
+        it 'redirects' do
+          expect(status).to eq(302)
+        end
+
+        it 'sets the cookie' do
+          expect(cookie).to match(/euCookieNotice=accepted;/)
+          expect(cookie).to match(/domain=www\.nature\.com:80;/)
+          expect(cookie).to match(/path=\/;/)
+          expect(cookie).to match(/expires=Wed, 31 Jan 2018 00:00:00 -0000/)
+        end
+
+        it 'redirects back to the original url' do
+          expect(location).to eq('http://www.nature.com/?cookies=accepted')
+        end
+
+        context 'and the referrer is set' do
+          let(:extra_headers) { { 'HTTP_REFERER' => 'http://www.nature.com/articles/ncomms7169' } }
+
+          it 'redirects back to the referrer' do
+            expect(location).to eq('http://www.nature.com/articles/ncomms7169')
+          end
+        end
+      end
+
+      context 'and the euNoticeCookie is set' do
+        let(:extra_headers) { { 'HTTP_COOKIE' => 'euCookieNotice=accepted' } }
+
+        it 'calls the app' do
+          expect(app).to receive(:call).with(env).and_call_original
+          expect(response).to eq([200, {}, %w[body]])
+        end
+      end
+    end
+  end
+
+  context 'when request params does not cookies=accepted' do
+    let(:url) { 'http://www.nature.com/' }
+
+    context 'and the request method is GET' do
+      let(:request_method) { 'GET' }
+
+      it 'calls the app' do
+        expect(app).to receive(:call).with(env).and_call_original
+        expect(response).to eq([200, {}, %w[body]])
+      end
+    end
+
+    context 'and the request method is POST' do
+      let(:request_method) { 'POST' }
+
+      it 'calls the app' do
+        expect(app).to receive(:call).with(env).and_call_original
+        expect(response).to eq([200, {}, %w[body]])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This middleware responds to a POST request with the params `cookies=accepted` by setting the `euCookieNotice` cookie to `accepted` on the request's host with a path of `/`. It is also set to expire in one year.

The middleware then redirects to the referrer if one is specified or the original request url if one isn't. The referrer must be on the same host and port otherwise it falls back to the original request url. This is to prevent use for [open redirection][1].

http://powerplant.nature.com/jira/browse/MAESUPP-109

[1]: https://webmasters.googleblog.com/2009/01/open-redirect-urls-is-your-site-being.html