### PR TITLE
Reverting a couple of recent additions to .rubocop.yml:

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,25 +31,6 @@ Style/AlignParameters:
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%':  ()
-    '%i': ()
-    '%I': ()
-    '%q': ()
-    '%Q': ()
-    '%r': '{}'
-    '%s': ()
-    '%w': '[]'
-    '%W': '[]'
-    '%x': ()
-
-Style/RegexpLiteral:
-  AllowInnerSlashes: true
-
 Style/CollectionMethods:
   PreferredMethods:
     collect: 'map'


### PR DESCRIPTION
We've been working to the default standards for a while now, and we have searched for ideas about this online, but can't find reasons not to stick to this. Open to suggestions though!