### PR TITLE
Reduce logging by cookie message middleware

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,13 @@ Metrics/BlockLength:
     - describe
     - context
 
+Metrics/MethodLength:
+  CountComments: false
+  Max: 20
+
+Metrics/AbcSize:
+  Max: 40
+
 Style/Documentation:
   Enabled: false
 
@@ -14,6 +21,15 @@ Style/SpaceBeforeFirstArg:
   Enabled: false
 
 Style/BracesAroundHashParameters:
+  Enabled: false
+
+Style/CaseEquality:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/ConditionalAssignment:
   Enabled: false
 
 Style/IndentHash:

--- a/macmillan-utils.gemspec
+++ b/macmillan-utils.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'syslog-logger'
   spec.add_dependency 'rubocop'
   spec.add_dependency 'colorize'
+  spec.add_dependency 'activesupport', '>= 3.2.0'
 end


### PR DESCRIPTION
The syslogs.nature.com server is being spammed by logs from the cookie message middleware because it logs at the default :info level for production apps. To reduce the volume of output, log at the debug level and provide a way to override the logger if more info is needed in a production application.