### PR TITLE
We noticed that apps using the CookieMessage middleware errored if th…

### DIFF
--- a/lib/macmillan/utils/middleware/cookie_message.rb
+++ b/lib/macmillan/utils/middleware/cookie_message.rb
@@ -15,16 +15,14 @@ module Macmillan
           @log_level = options[:log_level]
 
           if (logger = options[:logger])
-            if logger.respond_to?(:tagged)
-              @logger = logger
-            else
-              @logger = ActiveSupport::TaggedLogging.new(logger)
-            end
+            build_tagged_logger(logger)
           end
         end
 
         def call(env)
           @request = Rack::Request.new(env)
+
+          build_tagged_logger(logger)
 
           if cookies_accepted?(@request)
             redirect_back(@request)
@@ -34,6 +32,14 @@ module Macmillan
         end
 
         private
+
+        def build_tagged_logger(logger)
+          if logger.respond_to?(:tagged)
+            @logger = logger
+          else
+            @logger = ActiveSupport::TaggedLogging.new(logger)
+          end
+        end
 
         def cookies_accepted?(request)
           debug("request.post? IS #{request.post?.inspect}")

--- a/spec/lib/macmillan/utils/middleware/cookie_message_spec.rb
+++ b/spec/lib/macmillan/utils/middleware/cookie_message_spec.rb
@@ -156,9 +156,31 @@ RSpec.describe Macmillan::Utils::Middleware::CookieMessage do
       end
     end
 
-    context 'custom logger' do
+    context 'custom logger that does not support tags' do
       let(:logger) { ::Logger.new(output) }
+
       subject { described_class.new(app, logger: logger) }
+
+      it 'produces tagged output' do
+        expect(app).to receive(:call).with(env).and_call_original
+        expect(response).to eq([200, {}, %w[body]])
+        expect(output).to have_output(/\[Macmillan::Utils::Middleware::CookieMessage\]/)
+        expect(output).to have_output(/request.post\? \(false\) means passthru/)
+      end
+    end
+
+    context 'custom logger that does not support tags - provided by Rack' do
+      let(:extra_headers) do
+        {
+          'rack.logger' => ::Logger.new(output)
+        }
+      end
+
+      subject { described_class.new(app) }
+
+      it 'does not throw an error due to missing "tagged" def' do
+        expect{ response }.not_to raise_error
+      end
 
       it 'produces tagged output' do
         expect(app).to receive(:call).with(env).and_call_original


### PR DESCRIPTION
…ey supply a logger that doesn't respond to the 'tagged' def, via rack.logger. Testing for this and supplying a fix