### PR TITLE
use only rubocop cops that refer to style guide

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,23 +1,30 @@
+AllCops:
+  StyleGuideCopsOnly: true
+
 Metrics/LineLength:
   Description: 'Limit lines to 120 characters.'
   Max: 120
+  Enabled: true
 
 Metrics/BlockLength:
   ExcludedMethods:
     - describe
     - context
+  Enabled: true
 
 Metrics/MethodLength:
   CountComments: false
   Max: 20
+  Enabled: true
 
 Metrics/AbcSize:
   Max: 40
+  Enabled: true
 
 Style/Documentation:
   Enabled: false
 
-Style/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Enabled: false
 
 Style/BracesAroundHashParameters:
@@ -32,20 +39,23 @@ Style/GuardClause:
 Style/ConditionalAssignment:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   EnforcedStyle: consistent
+  Enabled: true
 
-Style/AlignHash:
+Layout/AlignHash:
   Severity: fatal
   Enabled: true
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
+  Enabled: true
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+  Enabled: true
 
 Style/CollectionMethods:
   PreferredMethods:
@@ -55,14 +65,16 @@ Style/CollectionMethods:
     detect: 'find'
     find_all: 'select'
 
-Style/DotPosition:
+Layout/DotPosition:
   EnforcedStyle: leading
+  Enabled: true
 
 Style/DoubleNegation:
   Enabled: false
 
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   # When true, allows most uses of extra spacing if the intent is to align
   # with an operator on the previous or next line, not counting empty lines
   # or comment lines.
   AllowForAlignment: true
+  Enabled: true


### PR DESCRIPTION
plus some other changes for current version of rubocop 0.49