### PR TITLE
Change EU cookie domain to wildcard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ tmp
 mkmf.log
 RBENV_VERSION*
 Gemfile.lock
+/.idea/
+*.iml
+

--- a/lib/macmillan/utils/middleware/cookie_message.rb
+++ b/lib/macmillan/utils/middleware/cookie_message.rb
@@ -94,7 +94,7 @@ module Macmillan
         def cookie_options(request)
           {
             value:    'accepted',
-            domain:   request.host_with_port,
+            domain:   ".#{request.host_with_port.split('.').drop(1).join('.')}",
             path:     '/',
             httponly: true,
             expires:  Time.now.getutc + YEAR

--- a/spec/lib/macmillan/utils/middleware/cookie_message_spec.rb
+++ b/spec/lib/macmillan/utils/middleware/cookie_message_spec.rb
@@ -43,10 +43,22 @@ RSpec.describe Macmillan::Utils::Middleware::CookieMessage do
 
         it 'sets the cookie' do
           expect(cookie).to match(/euCookieNotice=accepted;/)
-          expect(cookie).to match(/domain=www\.nature\.com:80;/)
+          expect(cookie).to match(/domain=\.nature\.com:80;/)
           expect(cookie).to match(%r{path=/;})
           expect(cookie).to match(/expires=Wed, 31 Jan 2018 00:00:00 -0000/)
           expect(cookie).to match(/httponly/i)
+        end
+
+        context 'and  the domain non-standard' do
+          let(:url) { 'http://test-www.naturechina.com:5124/?cookies=accepted' }
+
+          it 'sets the cookie' do
+            expect(cookie).to match(/euCookieNotice=accepted;/)
+            expect(cookie).to match(/domain=\.naturechina\.com:5124;/)
+            expect(cookie).to match(%r{path=/;})
+            expect(cookie).to match(/expires=Wed, 31 Jan 2018 00:00:00 -0000/)
+            expect(cookie).to match(/httponly/i)
+          end
         end
 
         it 'redirects back to the original url' do


### PR DESCRIPTION
This changes the EU cookie domain to remove the first subdomain, wildcarding the cookie. This is intended to allow cookie banners to be consistent across subdomains, particular as we change subdomain for authentication purposes.